### PR TITLE
コマンドライン引数を受け取る

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,6 +18,49 @@ dependencies = [
  "memchr",
  "regex-automata",
  "serde",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+
+[[package]]
+name = "clap"
+version = "4.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -40,7 +89,66 @@ dependencies = [
 name = "csv-spliter"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "csv",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -56,16 +164,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "libc"
+version = "0.2.139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "once_cell"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "rustix"
+version = "0.36.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "ryu"
@@ -78,3 +266,129 @@ name = "serde"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.0.32", features = ["derive"] }
 csv = "1.1.6"

--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -1,0 +1,39 @@
+use csv::{StringRecord, Writer};
+use std::error::Error;
+
+pub struct CSVFragment {
+    header: StringRecord,
+    records: Vec<StringRecord>,
+    capacity: usize,
+}
+
+impl CSVFragment {
+    pub fn new(header: StringRecord, capacity: usize) -> Self {
+        CSVFragment {
+            header: header.clone(),
+            records: Vec::<StringRecord>::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    pub fn write_records_to_file(&self, filepath: &str) -> Result<(), Box<dyn Error>> {
+        let mut writer = Writer::from_path(filepath)?;
+        writer.write_record(&self.header)?;
+        for record in &self.records {
+            writer.write_record(record)?;
+        }
+        writer.flush()?;
+        Ok(())
+    }
+
+    pub fn push(&mut self, row: StringRecord) {
+        self.records.push(row);
+    }
+
+    pub fn is_full(&self) -> bool {
+        self.records.len() == self.capacity
+    }
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+}

--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -1,5 +1,5 @@
 use csv::{StringRecord, Writer};
-use std::error::Error;
+use std::{error::Error, path::PathBuf};
 
 pub struct CSVFragment {
     header: StringRecord,
@@ -16,7 +16,7 @@ impl CSVFragment {
         }
     }
 
-    pub fn write_records_to_file(&self, filepath: &str) -> Result<(), Box<dyn Error>> {
+    pub fn write_records_to_file(&self, filepath: &PathBuf) -> Result<(), Box<dyn Error>> {
         let mut writer = Writer::from_path(filepath)?;
         writer.write_record(&self.header)?;
         for record in &self.records {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,21 @@ use clap::Parser;
 mod fragment;
 mod split;
 
+/// Simple CSV file splitter
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
+    /// CSV file to split
     input_filepath: String,
+
+    /// Line count of each splitted file
     line_count: usize,
+
+    /// Output file prefix
     #[arg(short, long)]
     prefix: Option<String>,
+
+    /// Output file directory
     #[arg(short, long)]
     output_dir: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-use std::env;
-
 use clap::Parser;
 
 mod fragment;
@@ -8,7 +6,7 @@ mod split;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    input_filename: String,
+    input_filepath: String,
     line_count: usize,
     #[arg(short, long)]
     prefix: Option<String>,
@@ -17,12 +15,9 @@ struct Args {
 }
 
 fn main() {
-    let filepath: String = env::args().nth(1).expect("File path not given");
-    let line_count_str: String = env::args().nth(2).expect("Missing line count");
-    let line_count: usize = line_count_str
-        .parse()
-        .expect("Line count should be a number");
-    let file_prefix = "prefix_"; // TODO: 引数として受け取る
+    let args = Args::parse();
+    let file_prefix = args.prefix.unwrap_or(String::from("./"));
 
-    split::split_csv(filepath, line_count, file_prefix).expect("Split csv failed: ");
+    split::split_csv(args.input_filepath, args.line_count, &file_prefix)
+        .expect("Split csv failed: ");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,55 +1,28 @@
 use std::env;
-use std::process;
 
-use crate::split::CSVFragment;
+use clap::Parser;
 
+mod fragment;
 mod split;
 
-fn generate_csv_file_name(file_prefix: &str, index: usize) -> String {
-    format!("{}{}.csv", file_prefix, index)
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    input_filename: String,
+    line_count: usize,
+    #[arg(short, long)]
+    prefix: Option<String>,
+    #[arg(short, long)]
+    output_dir: Option<String>,
 }
 
 fn main() {
     let filepath: String = env::args().nth(1).expect("File path not given");
     let line_count_str: String = env::args().nth(2).expect("Missing line count");
-    let file_prefix = "prefix_"; // TODO: 引数として受け取る
-
     let line_count: usize = line_count_str
         .parse()
         .expect("Line count should be a number");
-    let mut reader = match csv::Reader::from_path(&filepath) {
-        Err(why) => {
-            println!("cannot open {}: {}", &filepath, why);
-            process::exit(1);
-        }
-        Ok(content) => content,
-    };
-    let header = reader.headers().expect("No header").clone();
-    let mut csv_flagment = CSVFragment::new(header.clone(), line_count);
-    let mut file_iteration_counter = 1;
-    for result in reader.records() {
-        let record = match result {
-            Err(error) => {
-                println!("wrong csv format {}", error);
-                process::exit(1)
-            }
-            Ok(record) => record,
-        };
-        csv_flagment.push(record);
-        if csv_flagment.is_full() {
-            let csv_file_name = generate_csv_file_name(file_prefix, file_iteration_counter);
-            csv_flagment
-                .write_records_to_file(csv_file_name.as_str())
-                .expect("cannnot create file");
-            file_iteration_counter += 1;
-            csv_flagment = CSVFragment::new(header.clone(), line_count);
-        }
-    }
-    if csv_flagment.len() != 0 {
-        csv_flagment
-            .write_records_to_file(
-                generate_csv_file_name(file_prefix, file_iteration_counter).as_str(),
-            )
-            .expect("can not create file");
-    }
+    let file_prefix = "prefix_"; // TODO: 引数として受け取る
+
+    split::split_csv(filepath, line_count, file_prefix).expect("Split csv failed: ");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,14 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
-    let file_prefix = args.prefix.unwrap_or(String::from("./"));
+    let file_prefix = args.prefix.unwrap_or(String::from("split_"));
+    let output_dir = args.output_dir.unwrap_or(String::from("./"));
 
-    split::split_csv(args.input_filepath, args.line_count, &file_prefix)
-        .expect("Split csv failed: ");
+    split::split_csv(
+        args.input_filepath,
+        args.line_count,
+        &file_prefix,
+        &output_dir,
+    )
+    .expect("Split csv failed: ");
 }

--- a/src/split.rs
+++ b/src/split.rs
@@ -1,39 +1,51 @@
-use csv::{StringRecord, Writer};
 use std::error::Error;
+use std::process;
 
-pub struct CSVFragment {
-    header: StringRecord,
-    records: Vec<StringRecord>,
-    capacity: usize,
+use crate::fragment;
+
+fn generate_csv_file_name(file_prefix: &str, index: usize) -> String {
+    format!("{}{}.csv", file_prefix, index)
 }
 
-impl CSVFragment {
-    pub fn new(header: StringRecord, capacity: usize) -> Self {
-        CSVFragment {
-            header: header.clone(),
-            records: Vec::<StringRecord>::with_capacity(capacity),
-            capacity,
+pub fn split_csv(
+    filepath: String,
+    line_count: usize,
+    file_prefix: &str,
+) -> Result<(), Box<dyn Error>> {
+    let mut reader = match csv::Reader::from_path(&filepath) {
+        Err(why) => {
+            println!("cannot open {}: {}", &filepath, why);
+            process::exit(1);
+        }
+        Ok(content) => content,
+    };
+    let header = reader.headers().expect("No header").clone();
+    let mut csv_flagment = fragment::CSVFragment::new(header.clone(), line_count);
+    let mut file_iteration_counter = 1;
+    for result in reader.records() {
+        let record = match result {
+            Err(error) => {
+                println!("wrong csv format {}", error);
+                process::exit(1)
+            }
+            Ok(record) => record,
+        };
+        csv_flagment.push(record);
+        if csv_flagment.is_full() {
+            let csv_file_name = generate_csv_file_name(file_prefix, file_iteration_counter);
+            csv_flagment
+                .write_records_to_file(csv_file_name.as_str())
+                .expect("cannnot create file");
+            file_iteration_counter += 1;
+            csv_flagment = fragment::CSVFragment::new(header.clone(), line_count);
         }
     }
-
-    pub fn write_records_to_file(&self, filepath: &str) -> Result<(), Box<dyn Error>> {
-        let mut writer = Writer::from_path(filepath)?;
-        writer.write_record(&self.header)?;
-        for record in &self.records {
-            writer.write_record(record)?;
-        }
-        writer.flush()?;
-        Ok(())
+    if csv_flagment.len() != 0 {
+        csv_flagment
+            .write_records_to_file(
+                generate_csv_file_name(file_prefix, file_iteration_counter).as_str(),
+            )
+            .expect("can not create file");
     }
-
-    pub fn push(&mut self, row: StringRecord) {
-        self.records.push(row);
-    }
-
-    pub fn is_full(&self) -> bool {
-        self.records.len() == self.capacity
-    }
-    pub fn len(&self) -> usize {
-        self.records.len()
-    }
+    Ok(())
 }

--- a/src/split.rs
+++ b/src/split.rs
@@ -1,16 +1,21 @@
-use std::error::Error;
-use std::process;
-
 use crate::fragment;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::process;
 
 fn generate_csv_file_name(file_prefix: &str, index: usize) -> String {
     format!("{}{}.csv", file_prefix, index)
+}
+
+fn build_output_filepath(output_dir: &str, filename: &str) -> PathBuf {
+    Path::new(output_dir).join(filename)
 }
 
 pub fn split_csv(
     filepath: String,
     line_count: usize,
     file_prefix: &str,
+    output_dir: &str,
 ) -> Result<(), Box<dyn Error>> {
     let mut reader = match csv::Reader::from_path(&filepath) {
         Err(why) => {
@@ -32,19 +37,20 @@ pub fn split_csv(
         };
         csv_flagment.push(record);
         if csv_flagment.is_full() {
-            let csv_file_name = generate_csv_file_name(file_prefix, file_iteration_counter);
+            let csv_filename = generate_csv_file_name(file_prefix, file_iteration_counter);
+            let csv_filepath = build_output_filepath(output_dir, &csv_filename);
             csv_flagment
-                .write_records_to_file(csv_file_name.as_str())
+                .write_records_to_file(&csv_filepath)
                 .expect("cannnot create file");
             file_iteration_counter += 1;
             csv_flagment = fragment::CSVFragment::new(header.clone(), line_count);
         }
     }
     if csv_flagment.len() != 0 {
+        let csv_filename = generate_csv_file_name(file_prefix, file_iteration_counter);
+        let csv_filepath = build_output_filepath(output_dir, &csv_filename);
         csv_flagment
-            .write_records_to_file(
-                generate_csv_file_name(file_prefix, file_iteration_counter).as_str(),
-            )
+            .write_records_to_file(&csv_filepath)
             .expect("can not create file");
     }
     Ok(())


### PR DESCRIPTION
コマンドライン引数のパースに使う仕組みを`std::env`から`clap`に変更した。

一緒に、以下の２つのオプションを定義できるようにした

```
  -p, --prefix <PREFIX>          Output file prefix
  -o, --output-dir <OUTPUT_DIR>  Output file directory
```